### PR TITLE
strict phrase searching, field limit query adjustment

### DIFF
--- a/app/lib/core/Plugins/SearchEngine/SqlSearch.php
+++ b/app/lib/core/Plugins/SearchEngine/SqlSearch.php
@@ -771,7 +771,7 @@ class WLPlugSearchEngineSqlSearch extends BaseSearchPlugin implements IWLPlugSea
 							if(sizeof($va_ap_tmp) >= 2) {
 								$va_element = $this->_getElementIDForAccessPoint($pn_subject_tablenum, $vs_access_point);
 								
-								if ($va_element) {
+								if (isset($va_element['field_num'],$va_element['table_num'])) {
 									$vs_fld_num = $va_element['field_num'];
 									$vs_fld_table_num = $va_element['table_num'];
 									$vs_fld_limit_sql = " AND (swi.field_table_num = {$vs_fld_table_num} AND swi.field_num = '{$vs_fld_num}')";


### PR DESCRIPTION
When ‘strictPhraseSearching’ is set, construction of query for ‘Zend_Search_Lucene_Search_Query_Phrase’ is not always being constructed correctly. Field limit part($vs_fld_limit_sql) of the query should only be taken into account when field_num and table_num are provided. Which is not always the case. When not provided, mysql query fails. 

A check is needed on these values to avoid the failure. Fix in this pull request solves the problem.
