### PR TITLE
Display title on Entity image browse

### DIFF
--- a/themes/default/views/Browse/browse_results_images_html.php
+++ b/themes/default/views/Browse/browse_results_images_html.php
@@ -113,7 +113,7 @@
 					print ExternalCache::fetch($vs_cache_key, 'browse_result');
 				}else{			
 					$vs_idno_detail_link 	= caDetailLink($this->request, $qr_res->get("{$vs_table}.idno"), '', $vs_table, $vn_id);
-					$vs_label_detail_link 	= caDetailLink($this->request, $qr_res->get("{$vs_table}.preferred_labels.name"), '', $vs_table, $vn_id);
+					$vs_label_detail_link 	= caDetailLink($this->request, $qr_res->get("{$vs_table}.preferred_labels), '', $vs_table, $vn_id);
 					$vs_thumbnail = "";
 					$vs_type_placeholder = "";
 					$vs_typecode = "";


### PR DESCRIPTION
Set $vs_label_detail_link to {$vs_table}.preferred_labels, rather than {$vs_table}.preferred_labels.name. Previously, an entity name would not display in image browse mode, because an entity has a displayname rather than a name.