### PR TITLE
Fix breaking css typos in main stylesheet

### DIFF
--- a/themes/default/assets/pawtucket/css/main.css
+++ b/themes/default/assets/pawtucket/css/main.css
@@ -1364,7 +1364,7 @@ a.browseRemoveFacet img {
     left: 0px !important;
 }
 .front .jcarousel-control-next {
-    right:0px; !important;
+    right:0px !important;
 }
 .front .jcarousel-control-next,
 .front .jcarousel-control-prev {
@@ -3159,7 +3159,7 @@ div.caMediaOverlayRepThumbs a.selectedRep img{
 	padding: 5px;
 	/* min-width: 120px; */
 	max-width: 300px;
-	*/ min-height: 50px; */
+	/* min-height: 50px; */
 }
 
 /* ----------------- print specific styles ----------------------*/


### PR DESCRIPTION
Fix two typos that won't let css to validate correctly.