### PR TITLE
Set video captions when using VideoJS media viewer

### DIFF
--- a/app/lib/Media/MediaViewers/VideoJS.php
+++ b/app/lib/Media/MediaViewers/VideoJS.php
@@ -59,10 +59,10 @@
 				$o_view->setVar('id', $vs_id = 'caMediaOverlayTimebased_'.$t_instance->getPrimaryKey().'_'.($vs_display_type = caGetOption('display_type', $pa_data, caGetOption('display_version', $pa_data['display'], ''))));
 				
 				if (is_a($t_instance, "ca_object_representations")) {
-				    $poster = $t_instance->getMediaUrl('media', caGetOption('viewer_poster_version', $pa_data['display'], 'small'));
+					$poster = $t_instance->getMediaUrl('media', caGetOption('viewer_poster_version', $pa_data['display'], 'small'));
 					$va_viewer_opts = [
 						'id' => $vs_id, 'viewer_width' => caGetOption('viewer_width', $pa_data['display'], '100%'), 'viewer_height' => caGetOption('viewer_height', $pa_data['display'], '100%'),
-					    'poster_frame_url' => $poster
+						'poster_frame_url' => $poster, 'captions' => $t_instance->getCaptionFileList()
 					];
 					
 					if (!$t_instance->hasMediaVersion('media', $vs_version = caGetOption('display_version', $pa_data['display'], 'original'))) {


### PR DESCRIPTION
I noticed that captions are not being set in the $pa_options sent to Video.php when using the VideoJS media viewer.  This change adds them in a way similar to how TileViewer does it, so that VTT and SRT caption files are correctly displayed by video.js.