### PR TITLE
Don't allow read access to "public" sets

### DIFF
--- a/app/models/ca_sets.php
+++ b/app/models/ca_sets.php
@@ -1016,10 +1016,6 @@ class ca_sets extends BundlableLabelableBaseModelWithAttributes implements IBund
 			return ca_sets::$s_have_access_to_set_cache[$vn_set_id.'/'.$pn_user_id.'/'.$pn_access] = true;
 		}
 		
-		if (($t_set->get('access') > 0) && ($pn_access == __CA_SET_READ_ACCESS__)) {	 // public sets are readable by all
-			return ca_sets::$s_have_access_to_set_cache[$vn_set_id.'/'.$pn_user_id.'/'.$pn_access] = true; 
-		}
-		
 		//
 		// If user is admin or has set admin privs allow them access to the set
 		//


### PR DESCRIPTION
PR changes lightbox behavior to not allow read access to "public" sets. This is a holdover from olden tymes and has the effect in current versions of Pawtucket that any front-end created set is readable by any user. This was intentional once upon a time but is definitely counter intuitive and undesirable in the current UI. Lightboxes are now only readable to users and groups explicitly granted access, no matter  the public/private "access" field for the set.