### PR TITLE
Hide Orphaned Typenames

### DIFF
--- a/themes/default/views/Details/ca_collections_default_html.php
+++ b/themes/default/views/Details/ca_collections_default_html.php
@@ -80,19 +80,19 @@
 				<div class='col-md-6 col-lg-6'>
 					{{{<ifcount code="ca_collections.related" min="1" max="1"><label>Related collection</label></ifcount>}}}
 					{{{<ifcount code="ca_collections.related" min="2"><label>Related collections</label></ifcount>}}}
-					{{{<ifcount code="ca_collections.related" min="1"><unit relativeTo="ca_collections_x_collections"><unit relativeTo="ca_collections" delimiter="<br/>"><l>^ca_collections.related.preferred_labels.name</l></unit> (^relationship_typename)</unit></ifcount>}}}
+					{{{<unit relativeTo="ca_collections_x_collections"><ifdef code="ca_collections"><unit relativeTo="ca_collections" delimiter="<br/>"><l>^ca_collections.related.preferred_labels.name</l></unit> (^relationship_typename)</ifdef></unit>}}}
 					
 					{{{<ifcount code="ca_entities" min="1" max="1"><label>Related person</label></ifcount>}}}
 					{{{<ifcount code="ca_entities" min="2"><label>Related people</label></ifcount>}}}
-					{{{<ifcount code="ca_entities" min="1"><unit relativeTo="ca_entities_x_collections"><unit relativeTo="ca_entities" delimiter="<br/>"><l>^ca_entities.preferred_labels.displayname</l></unit> (^relationship_typename)</unit></ifcount>}}}
+					{{{<unit relativeTo="ca_entities_x_collections"><ifdef code="ca_entities"><unit relativeTo="ca_entities" delimiter="<br/>"><l>^ca_entities.preferred_labels.displayname</l></unit> (^relationship_typename)</ifdef></unit>}}}
 					
 					{{{<ifcount code="ca_occurrences" min="1" max="1"><label>Related occurrence</label></ifcount>}}}
 					{{{<ifcount code="ca_occurrences" min="2"><label>Related occurrences</label></ifcount>}}}
-					{{{<ifcount code="ca_occurrences" min="1"><unit relativeTo="ca_occurrences_x_collections"><unit relativeTo="ca_occurrences" delimiter="<br/>"><l>^ca_occurrences.preferred_labels.name</l></unit> (^relationship_typename)</unit></ifcount>}}}
+					{{{<unit relativeTo="ca_occurrences_x_collections"><ifdef code="ca_occurrences"><unit relativeTo="ca_occurrences" delimiter="<br/>"><l>^ca_occurrences.preferred_labels.name</l></unit> (^relationship_typename)</ifdef></unit>}}}
 					
 					{{{<ifcount code="ca_places" min="1" max="1"><label>Related place</label></ifcount>}}}
 					{{{<ifcount code="ca_places" min="2"><label>Related places</label></ifcount>}}}
-					{{{<ifcount code="ca_places" min="1"><unit relativeTo="ca_places_x_collections"><unit relativeTo="ca_places" delimiter="<br/>"><l>^ca_places.preferred_labels.name</l></unit> (^relationship_typename)</unit></ifcount>}}}					
+					{{{<unit relativeTo="ca_places_x_collections"><ifdef code="ca_places"><unit relativeTo="ca_places" delimiter="<br/>"><l>^ca_places.preferred_labels.name</l></unit> (^relationship_typename)</ifdef></unit>}}}					
 				</div><!-- end col -->
 			</div><!-- end row -->
 {{{<ifcount code="ca_objects" min="2">

--- a/themes/default/views/Details/ca_collections_default_html.php
+++ b/themes/default/views/Details/ca_collections_default_html.php
@@ -80,19 +80,19 @@
 				<div class='col-md-6 col-lg-6'>
 					{{{<ifcount code="ca_collections.related" min="1" max="1"><label>Related collection</label></ifcount>}}}
 					{{{<ifcount code="ca_collections.related" min="2"><label>Related collections</label></ifcount>}}}
-					{{{<unit relativeTo="ca_collections_x_collections"><unit relativeTo="ca_collections" delimiter="<br/>"><l>^ca_collections.related.preferred_labels.name</l></unit> (^relationship_typename)</unit>}}}
+					{{{<ifcount code="ca_collections.related" min="1"><unit relativeTo="ca_collections_x_collections"><unit relativeTo="ca_collections" delimiter="<br/>"><l>^ca_collections.related.preferred_labels.name</l></unit> (^relationship_typename)</unit></ifcount>}}}
 					
 					{{{<ifcount code="ca_entities" min="1" max="1"><label>Related person</label></ifcount>}}}
 					{{{<ifcount code="ca_entities" min="2"><label>Related people</label></ifcount>}}}
-					{{{<unit relativeTo="ca_entities_x_collections"><unit relativeTo="ca_entities" delimiter="<br/>"><l>^ca_entities.preferred_labels.displayname</l></unit> (^relationship_typename)</unit>}}}
+					{{{<ifcount code="ca_entities" min="1"><unit relativeTo="ca_entities_x_collections"><unit relativeTo="ca_entities" delimiter="<br/>"><l>^ca_entities.preferred_labels.displayname</l></unit> (^relationship_typename)</unit></ifcount>}}}
 					
 					{{{<ifcount code="ca_occurrences" min="1" max="1"><label>Related occurrence</label></ifcount>}}}
 					{{{<ifcount code="ca_occurrences" min="2"><label>Related occurrences</label></ifcount>}}}
-					{{{<unit relativeTo="ca_occurrences_x_collections"><unit relativeTo="ca_occurrences" delimiter="<br/>"><l>^ca_occurrences.preferred_labels.name</l></unit> (^relationship_typename)</unit>}}}
+					{{{<ifcount code="ca_occurrences" min="1"><unit relativeTo="ca_occurrences_x_collections"><unit relativeTo="ca_occurrences" delimiter="<br/>"><l>^ca_occurrences.preferred_labels.name</l></unit> (^relationship_typename)</unit></ifcount>}}}
 					
 					{{{<ifcount code="ca_places" min="1" max="1"><label>Related place</label></ifcount>}}}
 					{{{<ifcount code="ca_places" min="2"><label>Related places</label></ifcount>}}}
-					{{{<unit relativeTo="ca_places_x_collections"><unit relativeTo="ca_places" delimiter="<br/>"><l>^ca_places.preferred_labels.name</l></unit> (^relationship_typename)</unit>}}}					
+					{{{<ifcount code="ca_places" min="1"><unit relativeTo="ca_places_x_collections"><unit relativeTo="ca_places" delimiter="<br/>"><l>^ca_places.preferred_labels.name</l></unit> (^relationship_typename)</unit></ifcount>}}}					
 				</div><!-- end col -->
 			</div><!-- end row -->
 {{{<ifcount code="ca_objects" min="2">


### PR DESCRIPTION
When related items are "not accessible to public" we must wrap the `typename` display within `ifcount` or `ifdef` to avoid orphaned relationship tags.  Fixes #40