### PR TITLE
Corrected Carousel Init

### DIFF
--- a/themes/default/views/bundles/representation_viewer_html.php
+++ b/themes/default/views/bundles/representation_viewer_html.php
@@ -126,14 +126,8 @@
 						$('#detailRepresentationThumbnails #detailRepresentationThumbnail' + id).addClass('{{{active_representation_class}}}');
 						$('#detailRepresentationThumbnails #detailRepresentationThumbnail' + id + ' a').addClass('{{{active_representation_class}}}');
 					});
-					
-					
 				}
 			});
-			
-		//if({{{representation_id}}} > 0){
-		//	$('.jcarousel').jcarousel('scroll', $('#slide{{{representation_id}}}'));
-		//}
 	});
 </script>
 <?php

--- a/themes/default/views/bundles/representation_viewer_html.php
+++ b/themes/default/views/bundles/representation_viewer_html.php
@@ -62,7 +62,7 @@
 		$('.jcarousel').on('jcarousel:animate', function (event, carousel) {
 			$(carousel._element.context).find('li').hide().fadeIn(500);
 		}).on('jcarousel:createend jcarousel:animateend', function(event, carousel) {
-			var current_rep_id = parseInt($('.jcarousel').jcarousel('last').attr('id').replace('slide', ''));
+			var current_rep_id = parseInt($('.jcarousel').jcarousel('target').attr('id').replace('slide', ''));
 			var i = caSliderepresentation_ids.indexOf(current_rep_id);
 			console.log("current", current_rep_id, i, jQuery('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + current_rep_id).html());
 


### PR DESCRIPTION
jcarousel's `last` method does NOT return the "current" item, and this screws up the entire thumbnail system.  Substituting the `target` method resolves the problems.

Fixes #38