### PR TITLE
NOJIRA Support user creation in Shibboleth authentication adapter

### DIFF
--- a/app/lib/Auth/Adapters/Shibboleth.php
+++ b/app/lib/Auth/Adapters/Shibboleth.php
@@ -74,10 +74,7 @@ class ShibbolethAuthAdapter extends BaseAuthAdapter implements IAuthAdapter {
         $map = array_flip($this->auth_config->get('shibboleth_field_map'));
 	    $uid = array_shift($attrs[$map['uid']]);
 	    if (!$uid) { return false; }
-	    if (ca_users::find(['user_name' => $uid], ['returnAs' => 'count']) > 0) {
-	        return true;
-	    }
-	    return false;
+	    return true;
 	}
     # --------------------------------------------------------------------------------
 	/**


### PR DESCRIPTION
Currently there is a chicken and egg situation with the Shibboleth (SAML) authentication adapter. The ca_users::authenticate() method calls the AuthenticationManager::authenticate() which then calls Shibboleth::authenticate()  which will always fail because the adapter (shibboleth) says it supports (__CA_AUTH_ADAPTER_FEATURE_AUTOCREATE_USERS__ = true) auto creating users but then in the authenticate method it does a check to see whether the user exists in the CA database.

ca_users then goes on to say ok what's the username for the user from SAML and tries to get more user information for a username which it doesn't have because the user has not been authenticated.

This commit fixes that issue.