### PR TITLE
Moved carousel ajax from the animateend event to the scrollend event.

### DIFF
--- a/themes/default/views/bundles/representation_viewer_html.php
+++ b/themes/default/views/bundles/representation_viewer_html.php
@@ -61,27 +61,27 @@
 		/* Carousel initialization */
 		$('.jcarousel').on('jcarousel:animate', function (event, carousel) {
 			$(carousel._element.context).find('li').hide().fadeIn(500);
-		}).on('jcarousel:createend jcarousel:animateend', function(event, carousel) {
+		}).on('jcarousel:scrollend', function(event, carousel, target, animate) {
 			var current_rep_id = parseInt($('.jcarousel').jcarousel('target').attr('id').replace('slide', ''));
 			var i = caSliderepresentation_ids.indexOf(current_rep_id);
 			console.log("current", current_rep_id, i, jQuery('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + current_rep_id).html());
 
-			if (event.type == 'jcarousel:animateend') {
-				if (!jQuery('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + current_rep_id).html()) {
-					// load media via ajax
-					jQuery('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + current_rep_id).html('<div style=\'margin-top: 120px; text-align: center; width: 100%;\'>Loading...</div>');
-					jQuery('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + current_rep_id).load('<?php print caNavUrl($this->request, '*', '*', 'GetMediaInline', array('context' => $vs_context, 'id' => $vn_subject_id, 'representation_id' => '')); ?>' + caSliderepresentation_ids[i] + '/display/detail', function(e) {
-						// update carousel height with current slide height after ajax load
-						jQuery(this).find('img').bind('load', function() {
-							jQuery('.jcarousel').height($('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + current_rep_id).height());
-						});
+			if (!jQuery('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + current_rep_id).html()) {
+				// load media via ajax
+				jQuery('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + current_rep_id).html('<div style=\'margin-top: 120px; text-align: center; width: 100%;\'>Loading...</div>');
+				jQuery('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + current_rep_id).load('<?php print caNavUrl($this->request, '*', '*', 'GetMediaInline', array('context' => $vs_context, 'id' => $vn_subject_id, 'representation_id' => '')); ?>' + caSliderepresentation_ids[i] + '/display/detail', function(e) {
+					// update carousel height with current slide height after ajax load
+					jQuery(this).find('img').bind('load', function() {
+						jQuery('.jcarousel').height($('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + current_rep_id).height());
 					});
-				} else {
-					// update carousel height with current slide height
-					var h = $('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + current_rep_id).height();
-					if (h > 0) $('.jcarousel').height(h);
-				}
+				});
+			} else {
+				// update carousel height with current slide height
+				var h = $('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + current_rep_id).height();
+				if (h > 0) $('.jcarousel').height(h);
+
 			}
+		}).on('jcarousel:createend jcarousel:animateend', function(event, carousel) {
 <?php
 	if ($vs_show_annotations_mode == 'div') {
 ?>


### PR DESCRIPTION
Fixes #69 

When `slideContent` updates from the `animateend` event, jCarousel will scroll forward only.  When the `scrollend` event is used instead, the user may scroll either direction even when the slides are not yet loaded.

This does not fix the separate issue of the carousel scrolling out of view when clicking on the last thumbnail.