### PR TITLE
Prevent having double slash '//' in URL

### DIFF
--- a/app/helpers/browseHelpers.php
+++ b/app/helpers/browseHelpers.php
@@ -247,7 +247,7 @@ require_once(__CA_MODELS_DIR__.'/ca_lists.php');
 		$vs_default_facet = caGetOption('defaultFacet', $pa_options, null);
 		
 		$o_browse_config = caGetBrowseConfig();
-		$vs_key = '';//Session::getVar('objects_last_browse_id');
+		$vs_key = '_';//Session::getVar('objects_last_browse_id');
 		
 		if (!($va_browse_info = caGetInfoForBrowseType($vs_browse_type))) {
 			// invalid browse type – throw error


### PR DESCRIPTION
[This small change prevent having double slash '//' in URL which is replaced
by a single slash '/' later in routing and resulting missing view error.

The error is described here:
https://collectiveaccess.org/support/index.php?p=/discussion/299474/browse-view

URL as missing key where only single slash is visible.