### PR TITLE
Fix sorting by certain attributes

### DIFF
--- a/app/lib/BaseFindEngine.php
+++ b/app/lib/BaseFindEngine.php
@@ -734,7 +734,7 @@ class BaseFindEngine extends BaseObject {
 					FROM ca_attribute_values cav FORCE INDEX(i_sorting)
 					INNER JOIN {$attr_tmp_table} AS attr_tmp ON attr_tmp.attribute_id = cav.attribute_id
 					WHERE cav.element_id = ? 
-					ORDER BY cav.value_sortable {$direction}
+					ORDER BY cav.{$attr_val_sort_field} {$direction}
 					{$limit_sql}";
 					
 		$qr_sort = $this->db->query($sql, [$element_id]);
@@ -873,7 +873,7 @@ class BaseFindEngine extends BaseObject {
 					INNER JOIN {$hit_table} AS ht ON ht.row_id = t.{$table_pk}
 					{$filter_join}
 					WHERE cav.element_id = ? {$filter_where}
-					ORDER BY cav.value_sortable {$direction}
+					ORDER BY cav.{$attr_val_sort_field} {$direction}
 					{$limit_sql}"; 
 		$qr_sort = $this->db->query($sql, [$element_id]);
 		$sort_keys = [];


### PR DESCRIPTION
This fixes sorting by attributes which data type do not use `value_sortable` field for sorting.

This includes attribute of type currency, file size, floor plan, geocode, integer, length, time code, weight, and also date range in older versions of Providence.

A simple way to reproduce the bug this PR solves is to try to browse objects sorted by price. Using the default installation profile, each object has a `purchase_price` attribute, so you can add a "sort by price" sort in `browse.conf`:

```
browseTypes = {
        objects = {
                sortBy = {
                        Price = ca_objects.purchase_price,
                },
        },
}
```

You will see that Pawtucket fails to sort correctly in that case. It also fails to sort similar attributes from related tables.