### PR TITLE
Force display of media when last thumbnail clicked first.

### DIFF
--- a/themes/default/views/bundles/representation_viewer_html.php
+++ b/themes/default/views/bundles/representation_viewer_html.php
@@ -62,27 +62,54 @@
 		$('.jcarousel').on('jcarousel:animate', function (event, carousel) {
 			$(carousel._element.context).find('li').hide().fadeIn(500);
 		}).on('jcarousel:scroll', function(event, carousel, target, animate) {
-			var current_rep_id = parseInt(target.attr('id').replace('slide', ''));
+			if (typeof target == 'object') {
+				var current_rep_id = parseInt(target.attr('id').replace('slide', ''));
+			} else {
+				var current_rep_id = parseInt($('.jcarousel').jcarousel('target').attr('id').replace('slide', ''));
+			}
 			var i = caSliderepresentation_ids.indexOf(current_rep_id);
-			console.log("current", current_rep_id, i, jQuery('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + current_rep_id).html());
+			if (typeof target != 'object') {
+				if (target == '-=1') {
+					if (i == 0) {
+						i = caSliderepresentation_ids.length - 1;
+					} else {
+						i--;
+					}
+				} else {
+					if ( i == caSliderepresentation_ids.length - 1 ) {
+						i = 0;
+					} else {
+						i++;
+					}
+				}
+			}
+			let selection = '#slide' + caSliderepresentation_ids[i] + ' #slideContent' + caSliderepresentation_ids[i];
+			console.log("current", current_rep_id, i, jQuery(selection).html());
 
 			// When the last slide is requested, first ensure the 2nd-to-last slide is loaded, then load the last slide.
 			let extra_pass_needed = i > 0 && i == caSliderepresentation_ids.length - 1;
 			let done = false;
 			while (!done) {
 				if (extra_pass_needed) i--;
-				if (!jQuery('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + caSliderepresentation_ids[i]).html()) {
+				selection = '#slide' + caSliderepresentation_ids[i] + ' #slideContent' + caSliderepresentation_ids[i];
+				if (!jQuery(selection).html()) {
 					// load media via ajax
-					jQuery('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + caSliderepresentation_ids[i]).html('<div style=\'margin-top: 120px; text-align: center; width: 100%;\'>Loading...</div>');
-					jQuery('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + caSliderepresentation_ids[i]).load('<?php print caNavUrl($this->request, '*', '*', 'GetMediaInline', array('context' => $vs_context, 'id' => $vn_subject_id, 'representation_id' => '')); ?>' + caSliderepresentation_ids[i] + '/display/detail', function(e) {
-						// update carousel height with current slide height after ajax load
-						jQuery(this).find('img').bind('load', function() {
-							jQuery('.jcarousel').height($('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + caSliderepresentation_ids[i]).height());
+					jQuery(selection).html('<div style=\'margin-top: 120px; text-align: center; width: 100%;\'>Loading...</div>');
+					if (extra_pass_needed) {
+						jQuery(selection).load('<?php print caNavUrl($this->request, '*', '*', 'GetMediaInline', array('context' => $vs_context, 'id' => $vn_subject_id, 'representation_id' => '')); ?>' + caSliderepresentation_ids[i] + '/display/detail', function(e) {
+							// don't update carousel height this time, it only causes race problems.
 						});
-					});
+					} else {
+						jQuery(selection).load('<?php print caNavUrl($this->request, '*', '*', 'GetMediaInline', array('context' => $vs_context, 'id' => $vn_subject_id, 'representation_id' => '')); ?>' + caSliderepresentation_ids[i] + '/display/detail', function(e) {
+							// update carousel height with current slide height after ajax load
+							jQuery(this).find('img').bind('load', function() {
+								jQuery('.jcarousel').height($(selection).height());
+							});
+						});
+					}
 				} else if (!extra_pass_needed) {
 					// update carousel height with current slide height
-					var h = $('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + caSliderepresentation_ids[i]).height();
+					var h = $(selection).height();
 					if (h > 0) $('.jcarousel').height(h);
 				}
 				if (extra_pass_needed) {

--- a/themes/default/views/bundles/representation_viewer_html.php
+++ b/themes/default/views/bundles/representation_viewer_html.php
@@ -61,25 +61,36 @@
 		/* Carousel initialization */
 		$('.jcarousel').on('jcarousel:animate', function (event, carousel) {
 			$(carousel._element.context).find('li').hide().fadeIn(500);
-		}).on('jcarousel:scrollend', function(event, carousel) {
-			var current_rep_id = parseInt($('.jcarousel').jcarousel('target').attr('id').replace('slide', ''));
+		}).on('jcarousel:scroll', function(event, carousel, target, animate) {
+			var current_rep_id = parseInt(target.attr('id').replace('slide', ''));
 			var i = caSliderepresentation_ids.indexOf(current_rep_id);
 			console.log("current", current_rep_id, i, jQuery('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + current_rep_id).html());
 
-			if (!jQuery('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + current_rep_id).html()) {
-				// load media via ajax
-				jQuery('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + current_rep_id).html('<div style=\'margin-top: 120px; text-align: center; width: 100%;\'>Loading...</div>');
-				jQuery('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + current_rep_id).load('<?php print caNavUrl($this->request, '*', '*', 'GetMediaInline', array('context' => $vs_context, 'id' => $vn_subject_id, 'representation_id' => '')); ?>' + caSliderepresentation_ids[i] + '/display/detail', function(e) {
-					// update carousel height with current slide height after ajax load
-					jQuery(this).find('img').bind('load', function() {
-						jQuery('.jcarousel').height($('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + current_rep_id).height());
+			// When the last slide is requested, first ensure the 2nd-to-last slide is loaded, then load the last slide.
+			let extra_pass_needed = i > 0 && i == caSliderepresentation_ids.length - 1;
+			let done = false;
+			while (!done) {
+				if (extra_pass_needed) i--;
+				if (!jQuery('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + caSliderepresentation_ids[i]).html()) {
+					// load media via ajax
+					jQuery('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + caSliderepresentation_ids[i]).html('<div style=\'margin-top: 120px; text-align: center; width: 100%;\'>Loading...</div>');
+					jQuery('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + caSliderepresentation_ids[i]).load('<?php print caNavUrl($this->request, '*', '*', 'GetMediaInline', array('context' => $vs_context, 'id' => $vn_subject_id, 'representation_id' => '')); ?>' + caSliderepresentation_ids[i] + '/display/detail', function(e) {
+						// update carousel height with current slide height after ajax load
+						jQuery(this).find('img').bind('load', function() {
+							jQuery('.jcarousel').height($('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + caSliderepresentation_ids[i]).height());
+						});
 					});
-				});
-			} else {
-				// update carousel height with current slide height
-				var h = $('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + current_rep_id).height();
-				if (h > 0) $('.jcarousel').height(h);
-
+				} else if (!extra_pass_needed) {
+					// update carousel height with current slide height
+					var h = $('#slide' + caSliderepresentation_ids[i] + ' #slideContent' + caSliderepresentation_ids[i]).height();
+					if (h > 0) $('.jcarousel').height(h);
+				}
+				if (extra_pass_needed) {
+					i++;
+					extra_pass_needed = false;
+				} else {
+					done = true;
+				}
 			}
 		}).on('jcarousel:createend jcarousel:animateend', function(event, carousel) {
 <?php


### PR DESCRIPTION
Fixes #85 

For reasons I don't fully understand, the jCarousel was broken when the last thumbnail was clicked first and the aspect of the first media was taller than the last media.

This workaround fixes the problem by:
- Forcing the 2nd-to-last media to always load before the last media.
- Using the `scroll` event instead of `scrollend` to minimize race conditions.