### PR TITLE
Enabled client-side caching in the IIIF service.

### DIFF
--- a/app/lib/Service/IIIFService.php
+++ b/app/lib/Service/IIIFService.php
@@ -43,6 +43,8 @@ class IIIFService {
 	 * @throws Exception
 	 */
 	public static function dispatch(string $identifier, RequestHTTP $request, ResponseHTTP $response) {
+		$response->addHeader('Cache-Control', 'max-age=3600, private', true); // Cache all responses for 1 hour.
+
 		$va_path = array_filter(array_slice(explode("/", $request->getPathInfo()), 3), 'strlen');
 		$vs_key = $identifier."/".join("/", $va_path);
 		


### PR DESCRIPTION
Arbitrary value of 1 hour allows web browsers to close and re-open overlay viewers without requesting image tiles every time.  

Complements https://github.com/collectiveaccess/providence/pull/1612