### PR TITLE
Fixed wrong table reference

### DIFF
--- a/app/helpers/displayHelpers.php
+++ b/app/helpers/displayHelpers.php
@@ -4296,7 +4296,7 @@ function caRepresentationViewer($po_request, $po_data, $pt_subject, $pa_options=
 				$vn_index = null;
 				if($vn_rep_id == $vn_primary_id){
 					$vn_index = 0;
-				}elseif (!($vn_index = (int)$qr_reps->get(RepresentableBaseModel::getRepresentationRelationshipTableName($qr_reps->tableName()).'.rank'))) {
+				}elseif (!($vn_index = (int)$qr_reps->get(RepresentableBaseModel::getRepresentationRelationshipTableName($pt_subject->tableName()).'.rank'))) {
 					$vn_index = $qr_reps->get('ca_object_representations.representation_id');
 				}
 				$va_rep_info[$vn_index] = array("rep_id" => $vn_rep_id, "tag" => $va_rep_tags[$vn_rep_id]);


### PR DESCRIPTION
Fixes #115

By calling `getRepresentationRelationshipTableName` with a representation, the script was looking for a representation x representation relationship.  This is wrong.  The related object needs to be passed instead.