### PR TITLE
Update phpoffice/phpspreadsheet version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "opis/json-schema": "^1.0",
     "pear/file_marc": "~1.2",
     "phpoffice/phppresentation": "1.0.0",
-    "phpoffice/phpspreadsheet": "v1.22",
+    "phpoffice/phpspreadsheet": "v1.29.1",
     "phpoffice/phpword": "v0.18.*",
     "phpunit/phpunit": "^9.5",
     "srmklive/flysystem-dropbox-v2": ">=1.0.0",


### PR DESCRIPTION
There are 2 known vulnerabilities in phpoffice/phpspreadsheet https://www.cve.org/CVERecord?id=CVE-2024-45046
https://www.cve.org/CVERecord?id=CVE-2024-45048

Version 1.29.1 is the security patched version for these.

I have done preliminary tests on php 8.1 and seems to be working ok.

I tested (not sure if all of these use this library or not):  
- Export search results in spreadsheet format