### PR TITLE
Refactored Rep Thumbnail Clicks

### DIFF
--- a/themes/default/views/bundles/representation_viewer_html.php
+++ b/themes/default/views/bundles/representation_viewer_html.php
@@ -55,7 +55,7 @@ if ($representation_count > 1) {
 	let index = 0;
 	let slide_list = <?= json_encode($slide_list); ?>;
 	jQuery(document).ready(function() {
-		setItem(0);
+		setByIndex(0);
 		
 		jQuery('#detailRepNavPrev').on('click', function(e) {
 			previousItem();
@@ -70,25 +70,39 @@ if ($representation_count > 1) {
 	function nextItem() {
 		if(index < (slide_list.length - 1)) {
 			index = index + 1;
-			setItem(index);
+			setByIndex(index);
 		}
 		return false;
 	};
 	function previousItem() {
 		if(index > 0) {
 			index = index - 1;
-			setItem(index);
+			setByIndex(index);
+		}
+		return false;
+	};
+	function setByIndex(i) {
+		if((i >= 0) && (i < slide_list.length)) {
+			jQuery('#repViewerItemDisplay').html(slide_list[i]);
+
+			let repid = jQuery('#repViewerItemDisplay').children(":first").attr('data-representation_id');
+			let thumbid = jQuery('.repThumb[data-representation_id="' + repid + '"]').attr('id');
+
+			jQuery('.repThumb').removeClass('active');
+			jQuery('#' + thumbid).addClass('active');
+
+			index = i;
 		}
 		return false;
 	};
 	function setItem(i) {
-		if((i >= 0) && (i < slide_list.length)) {
-			jQuery('#repViewerItemDisplay').html(slide_list[i]);
-			
-			jQuery('.repThumb').removeClass('active');
-			jQuery('#repThumb_' + index).addClass('active');
-			
-			index = i;
+		let repid = jQuery('#repThumb_' + i).attr('data-representation_id');
+
+		for (let newindex = 0; newindex < slide_list.length; newindex++) {
+			if (slide_list[newindex].includes("data-representation_id='" + repid + "'")) {
+				setByIndex(newindex);
+				break;
+			}
 		}
 		return false;
 	};


### PR DESCRIPTION
Fixes #127 

The previous implementation assumed slides could be indexed using the thumbnail sequence, which does not work because thumbnails and slides are not in the same order unless the primary representation happens to be first.

This PR refactors the function `setItem` to assume the input is a thumbnail sequence number, **not** the slide array index and **not** the representation ID.  This function grabs the thumbnail's representation ID and scans the slide list to find the corresponding slide index.

Added function `setByIndex` which assumes the input is the targeted slide array index.  This function extracts the representation ID from the slide list and uses it to find the element ID of a corresponding thumbnail.