### PR TITLE
Don't try and render site page media if it doesn't exist fix #154

### DIFF
--- a/app/models/ca_site_pages.php
+++ b/app/models/ca_site_pages.php
@@ -386,7 +386,7 @@ class ca_site_pages extends BundlableLabelableBaseModelWithAttributes {
 			    foreach($va_media_to_render as $va_media) {
 			        $vn_index = (int)caGetOption('index', $va_media, 0) - 1;
 			        if ($vn_index < 0) { $vn_index = 0; }
-			        if ($vn_index > sizeof($va_media_list) - 1) { $vn_index = sizeof($va_media_list) - 1; }
+			        if ($vn_index > sizeof($va_media_list) - 1) { continue; }
 			        
 			        if (!isset($va_media_list[$vn_index])) { continue; }
 			        if (is_array($va_access_values) && !in_array($va_media_list[$vn_index]['access'], $va_access_values)) { continue; }


### PR DESCRIPTION
This changes the default behaviour when trying to render more media than available, from: showing last listed media multiple times, to: not load media.