### PR TITLE
Fix to issue with elements failing to render

### DIFF
--- a/app/lib/BaseModelWithAttributes.php
+++ b/app/lib/BaseModelWithAttributes.php
@@ -2390,7 +2390,7 @@ class BaseModelWithAttributes extends BaseModel implements ITakesAttributes {
 		}
 		
 		$vs_view_path = (isset($pa_options['viewPath']) && $pa_options['viewPath']) ? $pa_options['viewPath'] : $po_request->getViewsDirectoryPath();
-		$o_view = new View($po_request, "{$vs_view_path}/bundles/");
+		$o_view = new View($po_request, "{$vs_view_path}/Search/");
 		
 		$o_view->setVar('request', $po_request);
 		$o_view->setVar('elements', $va_elements_by_container);


### PR DESCRIPTION
Fixes #167 by reverting one of the lines changed in [the most recent commit to change this file](https://github.com/collectiveaccess/pawtucket2/commit/0ca25a3fe7fee5830213d0f6453386eedfd28f8c). Also fixes a broader issue with drop-down elements failing to display in the same way.