### PR TITLE
setup.php-dist __CA_APP_DIR__ not defined error fix

### DIFF
--- a/setup.php-dist
+++ b/setup.php-dist
@@ -63,8 +63,7 @@ if (!defined("__CA_DB_DATABASE__")) {
 #
 if (!defined("__CA_APP_DISPLAY_NAME__")) {
 	define("__CA_APP_DISPLAY_NAME__", "My First CollectiveAccess System");
-}  define("__CA_LOG_DIR__", __CA_APP_DIR__."/log");
-}
+}  
 
 # __CA_ADMIN_EMAIL__ = the email address from which to send administrative messages
 #


### PR DESCRIPTION
Removed 

if (!defined("__CA_LOG_DIR__")) {
        define("__CA_LOG_DIR__", __CA_APP_DIR__."/log");
}

from setup.php-dist

I believe it was mistakenly added in https://github.com/collectiveaccess/pawtucket2/commit/c09602c706cd4d5284158192941f94f5abd8660f#diff-15cef81e15416052a091284b9f0b335e15777ee0597012d9f5c085a7320dc4b9

It was meant to be added back to post-setup.php 

It was removed from post-setup.php in https://github.com/collectiveaccess/pawtucket2/commit/6eaa091020b0f7373aeccfe8680eca23ad180b2e#diff-97c766ff6f2262b482ee6fe494021716ab97d1d03153d2dabfffc300e0eec88f

It was added back to post-setup.php in https://github.com/collectiveaccess/pawtucket2/commit/047ba468ca2d9ddc0c3ad71bf65d35df6124050b

