### PR TITLE
add boilerplate code

### DIFF
--- a/app/lib/Browse/BrowseEngine.php
+++ b/app/lib/Browse/BrowseEngine.php
@@ -48,6 +48,8 @@ require_once(__CA_LIB_DIR__.'/Browse/BrowseCache.php');
 require_once(__CA_LIB_DIR__.'/Parsers/TimeExpressionParser.php');
 require_once(__CA_APP_DIR__.'/helpers/searchHelpers.php');
 require_once(__CA_APP_DIR__.'/helpers/accessHelpers.php');
+require_once(__CA_APP_DIR__.'/helpers/libraryServicesHelpers.php');
+
 
 class BrowseEngine extends BaseFindEngine {
 	# ------------------------------------------------------

--- a/app/lib/Plugins/SearchEngine/ElasticSearch.php
+++ b/app/lib/Plugins/SearchEngine/ElasticSearch.php
@@ -766,4 +766,8 @@ class WLPlugSearchEngineElasticSearch extends BaseSearchPlugin implements IWLPlu
 		return (defined('__CollectiveAccess_IS_REINDEXING__') && __CollectiveAccess_IS_REINDEXING__);
 	}
 	# -------------------------------------------------------
+
+	public function _resolveHitInformation($res) {
+		return $res;
+	}
 }


### PR DESCRIPTION
Fatal errors on missing functions for searches with ElasticSearch (7) searchengine.

_resolveHitInformation missing from the base class, and caGetLibraryServicesConfiguration from the not included helper.

must admit that I'm just scratching the surface on a (chinese) legacy elastic project, so not trying to be complete here.

I'm not entirely sure what _resolveHitInformation would need to do in the context of ES, from peeking at the SqlSearch2 implementation. Just passing on $res seems to list some results on a fairly basic 'any search' (still unverified if they are the correct items because there could be changes on how ES handles slashes in the newer versions).