### PR TITLE
Fix always-false config check for skipPathChecks and skip media dir if true

### DIFF
--- a/app/lib/pawtucket/ConfigurationCheck.php
+++ b/app/lib/pawtucket/ConfigurationCheck.php
@@ -57,7 +57,8 @@ final class ConfigurationCheck {
 		$va_methods = $vo_reflection->getMethods();
 		foreach($va_methods as $vo_method){
 			if(strpos($vo_method->name,"QuickCheck")!==false){
-			    if (caGetOption('skipPathChecks', $options, false) && in_array($vo_method->name, ['caUrlRootQuickCheck', 'caBaseDirQuickCheck'])) { continue; }
+			    if (self::$opo_config->get('skipPathChecks') &&
+					in_array($vo_method->name, ['caUrlRootQuickCheck', 'caBaseDirQuickCheck', 'mediaDirQuickCheck'])) { continue; }
 				if (!$vo_method->invoke(null, "ConfigurationCheck")) {
 					return;
 				}


### PR DESCRIPTION
Hi there, this fixes a couple little related issues.

### Problem
I wanted to use principle of least privilege with pawtucket2's media directory -- having it work when media is read-only to the application, since we don't accept uploads via pawtucket -- but I don't want to change CA's core code more than necessary.

The quick config check fails when the media dir isn't writable, but it works fine for this after a tune-up. In its function, there's some branching logic for a skipPathChecks option, but that option is always falsy when called by other functions. Also, when skipPathChecks is set to true, the media folder isn't checked.

### Resolution
* Ensure that the quick config check safely checks the configuration for skipPathChecks
* Add the media folder to the list of folder checks to ignore when skipPathChecks is truthy

### Impact
Nobody has been using skipPathChecks since this value is currently being ignored, so this shouldn't negatively impact anyone's installation, as it only changes CA's behavior when it's truthy.

I tested it on a vanilla install with and without this config key, and with and without the media folder writable.