### PR TITLE
Read in the extra query builder options from configuration

### DIFF
--- a/app/controllers/SearchController.php
+++ b/app/controllers/SearchController.php
@@ -601,6 +601,9 @@ class SearchController extends FindController {
 			'icons' => $search_builder_config->getAssoc('query_builder_icons'),
 			'sort_filters' => false
 		];
+		if($query_builder_global_options = $search_builder_config->getAssoc('query_builder_global_options')){
+			$builder_options = array_merge($builder_options, $query_builder_global_options);
+		}
 		$this->view->setVar('form_options', $builder_options);
 		
 		$this->render($va_search_info['view']);


### PR DESCRIPTION
I have tested this with the following configuration and it is working.

```
query_builder_global_options = {
        allow_groups = false,
        allow_empty = true,
        select_placeholder = Select field,
        lang = {
                add_rule = add field,
                
                operators = {
                        equal = equals,
                        not_equal = not equals,
                },
                conditions = {
                        AND = ALL,
                        OR = ANY
        }
}
```