### PR TITLE
Fire internal server error with quick config check failure response

### DIFF
--- a/index.php
+++ b/index.php
@@ -52,6 +52,7 @@
 		require_once(__CA_APP_DIR__.'/lib/pawtucket/ConfigurationCheck.php');
 		ConfigurationCheck::performQuick();
 		if(ConfigurationCheck::foundErrors()){
+			http_response_code(500); // send as Internal Server Error
 			ConfigurationCheck::renderErrorsAsHTMLOutput();
 			exit();
 		}


### PR DESCRIPTION
Hi there, here's a small change for your consideration. This sends an HTTP 500 Internal Server Error when the quick config check fails, while still sending the quick check response body.

Most people probably won't notice the change, but there are a couple advantages:

* For those behind a WAF or reverse proxy, the 500 error can be trapped with a generic outbound message to avoid publicizing the specifics of their configuration fails
* For those that aren't behind a WAF/proxy, the 500 error instructs search engines (well, Google at least) that the quick check page content should be ignored while it's in that state

Tested on default configuration. Repro'ed by pointing to an empty database in setup.php.